### PR TITLE
Update to version 2024.3.5

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -10,6 +10,6 @@
     <option name="languageVersion" value="2.1" />
   </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.0" />
+    <option name="version" value="2.1.20" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="zulu-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="ProjectType">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,15 @@
 plugins {
-  kotlin("jvm") version "2.1.0"
+  kotlin("jvm") version "2.1.20"
 
 //  kotlin("kapt") version "1.9.0" apply false
-  id("org.jetbrains.intellij.platform") version "2.2.1" apply false
+  id("org.jetbrains.intellij.platform") version "2.5.0" apply false
 
 //  id("org.openjfx.javafxplugin") version "0.0.14"
 //  id("org.beryx.jlink") version "2.26.0"
 }
 
 group = "cn.varsa"
-version = "1.6.6"
+version = "1.6.6.v202403"
 
 repositories {
   mavenLocal()

--- a/eclipse-pde-partial-idea/build.gradle.kts
+++ b/eclipse-pde-partial-idea/build.gradle.kts
@@ -14,8 +14,9 @@ repositories {
 
 dependencies {
   implementation(project(":common"))
+  implementation(kotlin("reflect"))
   intellijPlatform {
-    intellijIdeaCommunity("2023.3")
+    intellijIdeaCommunity("2024.3")
     bundledPlugins(listOf("com.intellij.java", "org.jetbrains.kotlin"))
     plugins(emptyList())
 
@@ -26,7 +27,7 @@ dependencies {
 }
 
 kotlin {
-  jvmToolchain(17)
+  jvmToolchain(21)
 }
 
 intellijPlatform {
@@ -38,7 +39,7 @@ intellijPlatform {
     changeNotes = File("$projectPath/CHANGES.html").readText(Charsets.UTF_8)
 
     ideaVersion {
-      sinceBuild = "233"
+      sinceBuild = "243"
     }
   }
 

--- a/eclipse-pde-partial-idea/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/config/TargetConfigurable.kt
+++ b/eclipse-pde-partial-idea/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/config/TargetConfigurable.kt
@@ -26,7 +26,6 @@ import org.osgi.framework.*
 import org.osgi.framework.Constants.*
 import java.awt.*
 import java.awt.event.*
-import java.util.*
 import javax.swing.*
 import javax.swing.tree.*
 
@@ -156,7 +155,7 @@ class TargetConfigurable(private val project: Project) : SearchableConfigurable,
       }
     }.apply {
       locationList.addListSelectionListener {
-        val event = AnActionEvent.createFromDataContext("", null) {}
+        val event = AnActionEvent.createEvent(DataContext.EMPTY_CONTEXT, null, "", ActionUiKind.NONE, null)
         update(event)
       }
     }
@@ -465,10 +464,10 @@ class TargetConfigurable(private val project: Project) : SearchableConfigurable,
         text = defaultPath
       }
     private val pathComponent = TextFieldWithBrowseButton(pathField).apply {
-      addBrowseFolderListener(title, description, project, fileDescription)
+      addBrowseFolderListener(project, fileDescription.withTitle(title).withDescription(description))
     }.let { LabeledComponent.create(it, description, BorderLayout.WEST) }
 
-    private val dependencyComboBox = ComboBox(DependencyScope.values().map { it.displayName }.toTypedArray())
+    private val dependencyComboBox = ComboBox(DependencyScope.entries.map { it.displayName }.toTypedArray())
     private val dependencyComponent = LabeledComponent.create(
       dependencyComboBox, message("config.target.locationDialog.dependency"), BorderLayout.WEST
     )
@@ -574,7 +573,7 @@ class TargetConfigurable(private val project: Project) : SearchableConfigurable,
         }
       }
 
-      bundle2FixBundle = HashMap<ShadowBundle, HashSet<FixBundle>>(initialCapacity)
+      bundle2FixBundle = HashMap(initialCapacity)
       bundles.values.flatMap { it.values }.flatten().filter { it.isChecked }.sortedBy { it.bundle.canonicalName }
         .forEach { bundle ->
           var problem: ProblemBundle? = null

--- a/eclipse-pde-partial-idea/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/config/TargetDefinitionService.kt
+++ b/eclipse-pde-partial-idea/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/config/TargetDefinitionService.kt
@@ -111,7 +111,7 @@ class TargetLocationDefinition(_location: String = "") : BackgroundResolvable {
   }
 
   override fun resolve(project: Project, indicator: ProgressIndicator) {
-    val scope = DependencyScope.values().firstOrNull { it.displayName == dependency } ?: DependencyScope.COMPILE
+    val scope = DependencyScope.entries.firstOrNull { it.displayName == dependency } ?: DependencyScope.COMPILE
     type = null
     val bundlesDefinitions = mutableListOf<BundleDefinition>()
     val featureDefinitions = mutableListOf<FeatureDefinition>()

--- a/eclipse-pde-partial-idea/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/helper/ModuleHelper.kt
+++ b/eclipse-pde-partial-idea/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/helper/ModuleHelper.kt
@@ -160,7 +160,7 @@ object ModuleHelper {
                 $BUNDLE_VENDOR: Varsa Studio
                 $REQUIRE_BUNDLE: org.eclipse.ui,
                  org.eclipse.core.runtime
-                $BUNDLE_REQUIREDEXECUTIONENVIRONMENT: ${JavaVersions.OpenJDK7.ee}
+                $BUNDLE_REQUIREDEXECUTIONENVIRONMENT: ${JavaVersions.OpenJDK17.ee}
                 $BUNDLE_ACTIVATIONPOLICY: $ACTIVATION_LAZY
                 $BUNDLE_CLASSPATH: .
 

--- a/eclipse-pde-partial-idea/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/kotlin/inspection/KotlinPackageAccessibilityInspection.kt
+++ b/eclipse-pde-partial-idea/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/kotlin/inspection/KotlinPackageAccessibilityInspection.kt
@@ -6,9 +6,10 @@ import cn.varsa.idea.pde.partial.plugin.inspection.*
 import cn.varsa.idea.pde.partial.plugin.kotlin.support.*
 import com.intellij.openapi.module.*
 import com.intellij.psi.*
-import org.jetbrains.kotlin.idea.quickfix.createFromUsage.callableBuilder.*
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.*
+import org.jetbrains.kotlin.idea.base.psi.*
+
 
 class KotlinPackageAccessibilityInspection : PackageAccessibilityInspection() {
 

--- a/eclipse-pde-partial-idea/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/resolver/PdeModuleCompileOnlyResolver.kt
+++ b/eclipse-pde-partial-idea/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/resolver/PdeModuleCompileOnlyResolver.kt
@@ -105,7 +105,8 @@ class PdeModuleCompileOnlyResolver : BuildLibraryResolver {
           add(it)
         }
       }.toTypedArray()
-      model.rearrangeOrderEntries(arrangeOrderEntries)
+      val sortedEntries = arrangeOrderEntries.sortedWith(compareBy {it.presentableName})
+      model.rearrangeOrderEntries(sortedEntries.toTypedArray())
     }
   }
 }


### PR DESCRIPTION
* Update build to 2024.3.5 and Jdk21
* Fix some deprecation warnings
* Save order entries to .iml in alphabetical order. This is to avoid creation of false changes to .iml since without explicit sorting, every resolve of workspace will save order entries to .iml in random order.