### PR TITLE
Support for JUnit-Plug-In tests #123

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = cn.varsa
 pluginName = Eclipse PDE Partial
 pluginRepositoryUrl = https://github.com/JaneWardSandy/eclipse-pde-partial-idea
 # SemVer format -> https://semver.org
-pluginVersion = 1.6.7
+pluginVersion = 1.6.7.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 243

--- a/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/run/MessageIds.kt
+++ b/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/run/MessageIds.kt
@@ -1,0 +1,139 @@
+package cn.varsa.idea.pde.partial.plugin.run
+
+/**
+ * Constants for message IDs used in a test communication protocol.
+ * Converted from org.eclipse.jdt.internal.junit.runner.MessageIds
+ */
+class MessageIds private constructor() { // Private constructor to prevent instantiation
+
+  companion object {
+    /**
+     * The header length of a message, all messages
+     * have a fixed header length
+     */
+    const val MSG_HEADER_LENGTH = 8
+
+    /**
+     * Notification that a test trace has started.
+     * The end of the trace is signaled by a TRACE_END
+     * message. In between the TRACE_START and TRACE_END
+     * the stack trace is submitted as multiple lines.
+     */
+    const val TRACE_START = "%TRACES "
+    /**
+     * Notification that a trace ends.
+     */
+    const val TRACE_END = "%TRACEE "
+    /**
+     * Notification that the expected result has started.
+     * The end of the expected result is signaled by a Trace_END.
+     */
+    const val EXPECTED_START = "%EXPECTS"
+    /**
+     * Notification that an expected result ends.
+     */
+    const val EXPECTED_END = "%EXPECTE"
+    /**
+     * Notification that the actual result has started.
+     * The end of the actual result is signaled by a Trace_END.
+     */
+    const val ACTUAL_START = "%ACTUALS"
+    /**
+     * Notification that an actual result ends.
+     */
+    const val ACTUAL_END = "%ACTUALE"
+    /**
+     * Notification that a trace for a reran test has started.
+     * The end of the trace is signaled by a RTrace_END
+     * message.
+     */
+    const val RTRACE_START = "%RTRACES"
+    /**
+     * Notification that a trace of a reran trace ends.
+     */
+    const val RTRACE_END = "%RTRACEE"
+    /**
+     * Notification that a test run has started.
+     * MessageIds.TEST_RUN_START + testCount.toString + " " + version
+     */
+    const val TEST_RUN_START = "%TESTC  "
+    /**
+     * Notification that a test has started.
+     * MessageIds.TEST_START + testID + "," + testName
+     */
+    const val TEST_START = "%TESTS  "
+    /**
+     * Notification that a test has ended.
+     * TEST_END + testID + "," + testName
+     */
+    const val TEST_END = "%TESTE  "
+    /**
+     * Notification that a test had an error.
+     * TEST_ERROR + testID + "," + testName.
+     * After the notification follows the stack trace.
+     */
+    const val TEST_ERROR = "%ERROR  "
+    /**
+     * Notification that a test had a failure.
+     * TEST_FAILED + testID + "," + testName.
+     * After the notification follows the stack trace.
+     */
+    const val TEST_FAILED = "%FAILED "
+    /**
+     * Notification that a test run has ended.
+     * TEST_RUN_END + elapsedTime.toString().
+     */
+    const val TEST_RUN_END = "%RUNTIME"
+    /**
+     * Notification that a test run was successfully stopped.
+     */
+    const val TEST_STOPPED = "%TSTSTP "
+    /**
+     * Notification that a test was reran.
+     * TEST_RERAN + testId + " " + testClass + " " + testName + STATUS.
+     * Status = "OK" or "FAILURE".
+     */
+    const val TEST_RERAN = "%TSTRERN"
+
+    /**
+     * Notification about a test inside the test suite. <br>
+     * TEST_TREE + testId + "," + testName + "," + isSuite + "," + testcount + "," + isDynamicTest +
+     * "," + parentId + "," + displayName + "," + parameterTypes + "," + uniqueId <br>
+     * isSuite = "true" or "false" <br>
+     * isDynamicTest = "true" or "false" <br>
+     * parentId = the unique id of its parent if it is a dynamic test, otherwise can be "-1" <br>
+     * displayName = the display name of the test <br>
+     * parameterTypes = comma-separated list of method parameter types if applicable, otherwise an
+     * empty string <br>
+     * uniqueId = the unique ID of the test provided by JUnit launcher, otherwise an empty string
+     * <br>
+     * See: ITestRunListener2#testTreeEntry
+     */
+    const val TEST_TREE = "%TSTTREE"
+    /**
+     * Request to stop the current test run.
+     */
+    const val TEST_STOP = ">STOP    "
+    /**
+     * Request to rerun a test.
+     * TEST_RERUN + testId + " " + testClass + " "+testName
+     */
+    const val TEST_RERUN = ">RERUN  "
+
+    /**
+     * MessageFormat to encode test method identifiers:
+     * testMethod(testClass)
+     */
+    const val TEST_IDENTIFIER_MESSAGE_FORMAT = "{0}({1})"
+
+    /**
+     * Test identifier prefix for ignored tests.
+     */
+    const val IGNORED_TEST_PREFIX = "@Ignore: "
+
+    /**
+     * Test identifier prefix for tests with assumption failures.
+     */
+    const val ASSUMPTION_FAILED_TEST_PREFIX = "@AssumptionFailure: "
+  }
+}

--- a/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/run/RemoteTestRunnerClient.kt
+++ b/src/main/kotlin/cn/varsa/idea/pde/partial/plugin/run/RemoteTestRunnerClient.kt
@@ -1,0 +1,258 @@
+package cn.varsa.idea.pde.partial.plugin.run
+
+import cn.varsa.idea.pde.partial.plugin.i18n.EclipsePDEPartialBundles.message
+import com.intellij.execution.ExecutionResult
+import com.intellij.openapi.util.Key
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.ArrayList
+import java.util.Scanner
+import kotlin.concurrent.thread
+import kotlin.text.startsWith
+import kotlin.text.substring
+
+/**
+ * Client for remote plugin test runner
+ */
+class RemoteTestRunnerClient {
+  private var serverSocket: ServerSocket? = null
+
+  private var testExecuted = 0
+  private var testErrors = 0
+  private var testFailures = 0
+  private val expectedBuffer = StringBuilder()
+  private val actualBuffer = StringBuilder()
+  private val traceBuffer = StringBuilder()
+  private var currentTestIdentifier = ""
+  private var currentTestError = false
+  private var currentTestFail = false
+  private var elapsedTime = 0
+
+  /**
+   * Create server socket
+   * @return local port
+   */
+  fun createServerSocket(): Int {
+    if (serverSocket == null)
+      serverSocket = ServerSocket(0)
+    return serverSocket!!.localPort
+  }
+
+  private fun convertTestIdentifier(identifier: String): String {
+    // 1. Split the string by the first comma
+    val parts = identifier.split(',', limit = 2)
+
+    // Check if we got exactly two parts (id and method(class))
+    if (parts.size != 2) {
+      // Throw an exception instead of returning null
+      throw IllegalArgumentException(message("remote.test.runner.client.invalidTestIdentifier", identifier))
+    }
+
+    val methodAndClass = parts[1] // This is "methodName(className)"
+
+    // 2. Find the parentheses to extract method name and class name
+    val openParenIndex = methodAndClass.indexOf('(')
+    val closeParenIndex = methodAndClass.indexOf(')')
+
+    // Check if parentheses are present and in the correct order
+    if (openParenIndex == -1 || closeParenIndex == -1 || openParenIndex >= closeParenIndex) {
+      // Throw an exception instead of returning null
+      throw IllegalArgumentException(message("remote.test.runner.client.invalidMethodClassFormat", methodAndClass, identifier))
+    }
+
+    // 3. Extract method name and class name using substring
+    val methodName = methodAndClass.substring(0, openParenIndex)
+    val className = methodAndClass.substring(openParenIndex + 1, closeParenIndex)
+
+    // 4. Construct the desired output string
+    return "$className.$methodName()"
+  }
+
+  /**
+   * Start background monitoring of remote test runner
+   */
+  fun start(executionResult : ExecutionResult) {
+    if (serverSocket != null) {
+      val key = Key.create<String>("RemoteTestRunnerClient")
+      thread {
+        val failures = ArrayList<Map<String, String>>()
+        val errors = ArrayList<Map<String, String>>()
+
+        val client = serverSocket?.accept()
+        if (client != null) {
+          val reader = Scanner(client.getInputStream())
+          while (serverSocket != null) {
+            val message = reader.nextLine()
+            if (message == null || message == "") {
+              continue
+            } else {
+              if (message.startsWith(MessageIds.TEST_START)) {
+                onTestStart(message, executionResult, key)
+              } else if (message.startsWith(MessageIds.TEST_END)) {
+                onTestEnd(failures, errors)
+              } else if (message.startsWith(MessageIds.TEST_ERROR)) {
+                onTestError()
+              } else if (message.startsWith(MessageIds.TEST_FAILED)) {
+                onTestFailed()
+              } else if (message.startsWith(MessageIds.EXPECTED_START)) {
+                onExpectedStart(reader)
+              } else if (message.startsWith(MessageIds.ACTUAL_START)) {
+                onActualStart(reader)
+              } else if (message.startsWith(MessageIds.TRACE_START)) {
+                onTraceStart(reader)
+              } else if (message.startsWith(MessageIds.TEST_RUN_END)) {
+                onTestRunEnd(message, executionResult, key, errors, failures, client)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private fun onTestStart(
+    message: String, executionResult: ExecutionResult, key: Key<String>
+  ) {
+    currentTestIdentifier = convertTestIdentifier(message.substring(MessageIds.MSG_HEADER_LENGTH))
+    executionResult.processHandler.notifyTextAvailable(
+      "${message("remote.test.runner.client.testStart", currentTestIdentifier)} \n", key
+    )
+  }
+
+  private fun onTestEnd(
+    failures: ArrayList<Map<String, String>>, errors: ArrayList<Map<String, String>>
+  ) {
+    testExecuted++
+    if (currentTestFail) {
+      val map = mapOf(
+        "testIdentifier" to currentTestIdentifier,
+        "expected" to expectedBuffer.toString(),
+        "actual" to actualBuffer.toString(),
+        "trace" to traceBuffer.toString()
+      )
+      failures.add(map)
+    } else if (currentTestError) {
+      val map = mapOf(
+        "testIdentifier" to currentTestIdentifier,
+        "expected" to expectedBuffer.toString(),
+        "actual" to actualBuffer.toString(),
+        "trace" to traceBuffer.toString()
+      )
+      errors.add(map)
+    }
+    currentTestIdentifier = ""
+    currentTestFail = false
+    currentTestError = false
+    expectedBuffer.clear()
+    actualBuffer.clear()
+    traceBuffer.clear()
+  }
+
+  private fun onTestFailed() {
+    currentTestFail = true
+    testFailures++
+  }
+
+  private fun onTestError() {
+    currentTestError = true
+    testErrors++
+  }
+
+  private fun onActualStart(reader: Scanner) {
+    actualBuffer.clear()
+    while(true) {
+      val message = reader.nextLine()
+      if (message == null)
+        break
+      if (message.startsWith(MessageIds.ACTUAL_END))
+        break
+      if (actualBuffer.isNotEmpty()) actualBuffer.append("\n")
+      actualBuffer.append(message)
+    }
+  }
+
+  private fun onExpectedStart(reader: Scanner) {
+    expectedBuffer.clear()
+    while(true) {
+      val message = reader.nextLine()
+      if (message == null)
+        break
+      if (message.startsWith(MessageIds.EXPECTED_END))
+        break
+      if (expectedBuffer.isNotEmpty()) expectedBuffer.append("\n")
+      expectedBuffer.append(message)
+    }
+  }
+
+  private fun onTraceStart(reader: Scanner) {
+    traceBuffer.clear()
+    while (true) {
+      val message = reader.nextLine()
+      if (message == null)
+        break
+      if (message.startsWith(MessageIds.TRACE_END))
+        break
+      if (traceBuffer.isNotEmpty()) traceBuffer.append("\n")
+      traceBuffer.append(message)
+    }
+  }
+
+  private fun onTestRunEnd(
+    message: String,
+    executionResult: ExecutionResult,
+    key: Key<String>,
+    errors: ArrayList<Map<String, String>>,
+    failures: ArrayList<Map<String, String>>,
+    client: Socket
+  ) {
+    try {
+      val elapsedText = message.substring(MessageIds.MSG_HEADER_LENGTH)
+      elapsedTime = Integer.parseInt(elapsedText)
+      executionResult.processHandler.notifyTextAvailable(
+        "\n${message("remote.test.runner.client.summary", testExecuted, testErrors, testFailures)} \n", key
+      )
+      executionResult.processHandler.notifyTextAvailable("${message("remote.test.runner.client.elapsedTime", elapsedTime.toString())} \n", key)
+      if (errors.isNotEmpty()) {
+        executionResult.processHandler.notifyTextAvailable(
+          "\nErrors:\n", key
+        )
+        errors.forEach {
+          executionResult.processHandler.notifyTextAvailable(
+            "* TestIdentifier=${it["testIdentifier"]}\n", key
+          )
+          executionResult.processHandler.notifyTextAvailable(
+            "** Expected:\n${it["expected"]}\n", key
+          )
+          executionResult.processHandler.notifyTextAvailable(
+            "** Actual:\n${it["actual"]}\n", key
+          )
+          executionResult.processHandler.notifyTextAvailable(
+            "** Trace:\n${it["trace"]}\n\n", key
+          )
+        }
+      }
+      if (failures.isNotEmpty()) {
+        executionResult.processHandler.notifyTextAvailable(
+          "\nFailures:\n", key
+        )
+        failures.forEach {
+          executionResult.processHandler.notifyTextAvailable(
+            "* TestIdentifier=${it["testIdentifier"]}\n", key
+          )
+          executionResult.processHandler.notifyTextAvailable(
+            "** Expected:\n${it["expected"]}\n", key
+          )
+          executionResult.processHandler.notifyTextAvailable(
+            "** Actual:\n${it["actual"]}\n", key
+          )
+          executionResult.processHandler.notifyTextAvailable(
+            "** Trace:\n${it["trace"]}\n\n", key
+          )
+        }
+      }
+    } finally {
+      serverSocket = null
+      client.close()
+    }
+  }
+}

--- a/src/main/resources/messages/EclipsePDEPartialBundles_locale.properties
+++ b/src/main/resources/messages/EclipsePDEPartialBundles_locale.properties
@@ -155,3 +155,10 @@ resolver.pde.buildCompileOnly=Extra ClassPath Resolver
 #cn.varsa.idea.pde.partial.plugin.helper.PdeNotifier
 notification.group.standard=PDE notifications
 notification.group.important=PDE important messages
+
+#cn.varsa.idea.pde.partial.plugin.run.RemoteTestRunnerClient
+remote.test.runner.client.invalidTestIdentifier=Invalid test identifier format: Expecting 'id,method(class)'. Got '{0}'
+remote.test.runner.client.invalidMethodClassFormat=Invalid method/class format: Expecting 'method(class)'. Got '{0}' in '{1}'
+remote.test.runner.client.testStart=Testing {0}
+remote.test.runner.client.summary=Total Test Executed: {0}, Errors: {1}, Failures: {2}
+remote.test.runner.client.elapsedTime=Total Elapsed Time(ms): {0}


### PR DESCRIPTION
- Basic support for running JUnit5 plugin test
- A basic remote test runner client implementation that will output test result to console
- For PDE plugin test application (org.eclipse.pde.junit.runtime.coretestapplication), auto add -testLoaderClass, -loaderpluginname and -port program parameters
- User has to use -testpluginname {test bundle name} program parameter to specify the plugin test bundle
- User has to use one of -test, -classname. -classnames, -packagenamefile or -testnamefile program parameter to specify the test(s) to run
- How to specify the test(s) to run: 
  -test {test class name}:{test method name} 
  -classname {test class name} 
  -classnames {space separated test class names, ends with -} 
  -packagenamefile {absolute or relative path to text file with one test package name per line}
  -testnamefile {absolute or relative path to text file with one test class name per line}